### PR TITLE
Initial build for 0.2.3 ❄️

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ build:
   script:
     - export CMAKE_GENERATOR="Ninja"  # [not win]
     - set CMAKE_GENERATOR="Ninja"  # [win]
-    - {{ PYTHON }} -m pip install . -v --no-deps --no-build-isolation
+    - {{ PYTHON }} -m pip install . -v --no-deps --no-build-isolation --config-settings cmake.build-type="Release"
   skip: true  # [py<37 or win]
   missing_dso_whitelist:  # [s390x]
     - $RPATH/ld64.so.1    # [s390x]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ build:
     - export CMAKE_GENERATOR="Ninja"  # [not win]
     - set CMAKE_GENERATOR="Ninja"  # [win]
     - {{ PYTHON }} -m pip install . -v --no-deps --no-build-isolation
-  skip: true  # [py<37]
+  skip: true  # [py<37 or win]
   missing_dso_whitelist:  # [s390x]
     - $RPATH/ld64.so.1    # [s390x]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,53 @@
+{% set name = "laszip-python" %}
+{% set version = "0.2.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/tmontaigu/laszip-python/archive/refs/tags/{{ version }}.tar.gz
+  sha256: 31572639a928fabf7d60a340970c6ae256ae9382e0420e938d6ab237553ac57b
+
+build:
+  number: 0
+  script:
+    - export CMAKE_GENERATOR="Ninja"  # [not win]
+    - set CMAKE_GENERATOR="Ninja"  # [win]
+    - {{ PYTHON }} -m pip install . -v --no-deps --no-build-isolation
+  skip: true  # [py<37]
+  missing_dso_whitelist:  # [s390x]
+    - $RPATH/ld64.so.1    # [s390x]
+
+requirements:
+  build:
+    - {{ compiler('cxx') }}
+    - cmake
+    - ninja
+  host:
+    - pip
+    - python
+    - scikit-build-core
+    - pybind11 >=2.10
+    - laszip 3.4
+  run:
+    - python
+    - laszip 3.4
+
+test:
+  imports:
+    - laszip
+  commands:
+    - pip check
+  requires:
+    - pip
+
+about:
+  home: https://github.com/tmontaigu/laszip-python
+  summary: Python bindings for LASzip
+  description: Unofficial bindings between Python and LASzip made using pybind11.
+  license: MIT
+  license_family: MIT
+  license_file: License.txt
+  dev_url: https://github.com/tmontaigu/laszip-python
+  doc_url: https://github.com/tmontaigu/laszip-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://github.com/tmontaigu/laszip-python/archive/refs/tags/{{ version }}.tar.gz
   sha256: 31572639a928fabf7d60a340970c6ae256ae9382e0420e938d6ab237553ac57b
+  patches:
+    - patches/0001-Add-missing-includes.patch
 
 build:
   number: 0
@@ -24,6 +26,8 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake
     - ninja
+    - patch  # [not win]
+    - m2-patch  # [win]
   host:
     - pip
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
   host:
     - pip
     - python
-    - scikit-build-core
+    - scikit-build-core >=0.1.5
     - pybind11 >=2.10
     - laszip 3.4
   run:

--- a/recipe/patches/0001-Add-missing-includes.patch
+++ b/recipe/patches/0001-Add-missing-includes.patch
@@ -1,0 +1,34 @@
+From fe7a0da62661318779aa17226314724b6a441775 Mon Sep 17 00:00:00 2001
+From: Jean-Christophe Morin <jcmorin@anaconda.com>
+Date: Tue, 23 Jan 2024 17:21:29 -0500
+Subject: [PATCH] Add missing includes
+
+---
+ src/lasunzipper.cpp | 1 +
+ src/laszipper.cpp   | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/src/lasunzipper.cpp b/src/lasunzipper.cpp
+index b51ac96..dceb02e 100644
+--- a/src/lasunzipper.cpp
++++ b/src/lasunzipper.cpp
+@@ -3,6 +3,7 @@
+ #include <laszip/laszip_api.h>
+ 
+ #include <algorithm>
++#include <limits>
+ 
+ LasUnZipper::LasUnZipper(py::object &file_obj) : LasUnZipper(file_obj, laszip_DECOMPRESS_SELECTIVE_ALL) {}
+ 
+diff --git a/src/laszipper.cpp b/src/laszipper.cpp
+index e481f5f..f44fd99 100644
+--- a/src/laszipper.cpp
++++ b/src/laszipper.cpp
+@@ -1,3 +1,4 @@
++#include <limits>
+ #include "laszipper.h"
+ 
+ #include "laszip_error.h"
+-- 
+2.43.0
+


### PR DESCRIPTION
laszip-python 0.2.3 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-3900](https://anaconda.atlassian.net/browse/PKG-3900)
- [Upstream repository](https://github.com/tmontaigu/laszip-python/tree/0.2.3)

### Explanation of changes:

Initial build. Note that the package name on PyPI is `laszip`, but in conda-forge and defaults, `laszip` is the C+ library.

Also note that this feedstock doesn't exist on conda-forge.

[PKG-3900]: https://anaconda.atlassian.net/browse/PKG-3900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ